### PR TITLE
Remove debug logs from BMI calculator

### DIFF
--- a/src/BMI.js
+++ b/src/BMI.js
@@ -1,13 +1,9 @@
 export const getAverageBodyMassIndex = (people) => {
     try {
         const totalBodyMassIndex = people.reduce((total, person) => {
-            console.log('person: ', person);
             const bodyMassIndex = person.weight / (person.height * person.height);
-            console.log('body mass indexx: ', bodyMassIndex);
             return total + bodyMassIndex;
         }, 0);
-
-        console.log('testing')
 
         return totalBodyMassIndex / people.length;
     } catch (error) {
@@ -15,4 +11,3 @@ export const getAverageBodyMassIndex = (people) => {
         return error;
     }
 }
-


### PR DESCRIPTION
This pull request removes unnecessary debug logs from the Body Mass Index calculator function, leaving only informative logs.

[This PR and the changes in it were generated by Jira-GPT (wip)]